### PR TITLE
Fix: allow ffmpeg executable to be set through environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 "use strict";
 
 var spawn = require("child_process").spawn,
-	ffmpeg = spawn.bind(null, "ffmpeg"),
+	ffmpeg = spawn.bind(null, process.env.FFMPEG_PATH || "ffmpeg"),
 	fs = require("fs"),
 	through = require("through"),
 	concat = require("concat-stream");


### PR DESCRIPTION
This is the same format that https://github.com/parshap/node-ffmetadata uses for the FFMPEG environment variable.
